### PR TITLE
expose retry logic

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -10,7 +10,7 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-func retry(logger lager.Logger, retryPolicy RetryPolicy, sleeper Sleeper, action func() bool) {
+func Retry(logger lager.Logger, retryPolicy RetryPolicy, sleeper Sleeper, action func() bool) {
 	retryLogger := logger.Session("retry")
 	startTime := time.Now()
 

--- a/retry_hijackable_client.go
+++ b/retry_hijackable_client.go
@@ -17,7 +17,7 @@ func (d *RetryHijackableClient) Do(request *http.Request) (*http.Response, Hijac
 	var response *http.Response
 	var hijackCloser HijackCloser
 	var err error
-	retry(d.Logger, d.RetryPolicy, d.Sleeper, func() bool {
+	Retry(d.Logger, d.RetryPolicy, d.Sleeper, func() bool {
 		response, hijackCloser, err = d.HijackableClient.Do(request)
 		return err == nil || !retryable(err)
 	})

--- a/retry_round_tripper.go
+++ b/retry_round_tripper.go
@@ -46,7 +46,7 @@ func (d *RetryRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 
 	var response *http.Response
 	var err error
-	retry(d.Logger, d.RetryPolicy, d.Sleeper, func() bool {
+	Retry(d.Logger, d.RetryPolicy, d.Sleeper, func() bool {
 		response, err = d.RoundTripper.RoundTrip(request)
 		return err == nil || retryReadCloser.IsRead || !retryable(err)
 	})


### PR DESCRIPTION
We would like to use the exponentially-backing-off generic retry function outside of the provided `RoundTripper` implementation.

This PR just capitalises the function name to export it. What do you think of this? IMO an ideal API would remove the `Sleeper` parameter, and calls the `retry` function with a concrete `Sleeper` that uses `time.Sleep`.

cc @avade
