### PR TITLE
adding unexpected EOF as retry case

### DIFF
--- a/retryer.go
+++ b/retryer.go
@@ -41,4 +41,5 @@ var defaultRetryableErrors = []error{
 	errors.New("handshake failure"),
 	errors.New("handshake timeout"),
 	errors.New("timeout awaiting response headers"),
+	errors.New("unexpected EOF"),
 }


### PR DESCRIPTION
unintentionally closing http conns using gzip causes
malformed response on the other end resulting in a
EOF.

Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>
Co-authored-by: Krishna Mannem <kmannem@pivotal.io>