### PR TITLE
use the provided exponential backoff constructor

### DIFF
--- a/retry_backoff.go
+++ b/retry_backoff.go
@@ -31,12 +31,13 @@ func NewExponentialBackOffFactory(timeout time.Duration) BackOffFactory {
 }
 
 func (f *exponentialBackOffFactory) NewBackOff() BackOff {
-	return &backoff.ExponentialBackOff{
-		InitialInterval:     1 * time.Second,
-		RandomizationFactor: 0,
-		Multiplier:          2,
-		MaxInterval:         16 * time.Second,
-		MaxElapsedTime:      f.timeout,
-		Clock:               backoff.SystemClock,
-	}
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 1 * time.Second
+	b.RandomizationFactor = 0
+	b.Multiplier = 2
+	b.MaxInterval = 16 * time.Second
+	b.MaxElapsedTime = f.timeout
+	b.Clock = backoff.SystemClock
+
+	return b
 }

--- a/retry_backoff_test.go
+++ b/retry_backoff_test.go
@@ -1,0 +1,54 @@
+package retryhttp_test
+
+import (
+	"net/http"
+	"net/url"
+	"syscall"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/retryhttp"
+	"github.com/concourse/retryhttp/retryhttpfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RetryBackoffFactory", func() {
+	var (
+		fakeRoundTripper  *retryhttpfakes.FakeRoundTripper
+		testLogger        lager.Logger
+		retryRoundTripper *retryhttp.RetryRoundTripper
+		roundTripErr      error
+		retryableError    error
+		request           *http.Request
+	)
+
+	BeforeEach(func() {
+		retryableError = syscall.ECONNRESET // "connection reset by peer"
+		fakeRoundTripper = new(retryhttpfakes.FakeRoundTripper)
+		fakeRoundTripper.RoundTripReturns(nil, retryableError)
+		testLogger = lager.NewLogger("test")
+		request = &http.Request{URL: &url.URL{Path: "some-path"}}
+	})
+
+	Context("when using the exponential backoff factory", func() {
+		BeforeEach(func() {
+			retryRoundTripper = &retryhttp.RetryRoundTripper{
+				Logger:         testLogger,
+				BackOffFactory: retryhttp.NewExponentialBackOffFactory(3 * time.Second),
+				RoundTripper:   fakeRoundTripper,
+				Retryer:        &retryhttp.DefaultRetryer{},
+			}
+		})
+
+		It("it respects the timeout", func(done Done) {
+			_, roundTripErr = retryRoundTripper.RoundTrip(request)
+			Expect(roundTripErr).To(Equal(retryableError))
+			Expect(fakeRoundTripper.RoundTripCallCount()).To(Equal(2))
+
+			close(done)
+			// retries twice, after 1 and 2 seconds -> total time of 3 seconds, add
+			// extra second to timeout just to be safe
+		}, 4)
+	})
+})


### PR DESCRIPTION
closes concourse/concourse#6770

we missed some default values when we updated the package, so let's just
rely on the constructor to initialize it to some sane value.

what ended up happening was that one of those default values was a magic
number, which caused an infinite retry since the default initialized
value was not the same.

Signed-off-by: Clara Fu <cfu@pivotal.io>
Co-authored-by: Bohan Chen <bochen@pivotal.io>