### PR TITLE
compatibility: Use default retryer when none is provided

### DIFF
--- a/retry_hijackable_client.go
+++ b/retry_hijackable_client.go
@@ -25,7 +25,11 @@ func (d *RetryHijackableClient) Do(request *http.Request) (*http.Response, Hijac
 
 	backoff.Retry(func() error {
 		response, hijackCloser, err = d.HijackableClient.Do(request)
-		if err != nil && d.Retryer.IsRetryable(err) {
+		retryer := d.Retryer
+		if retryer == nil {
+			retryer = &DefaultRetryer{}
+		}
+		if err != nil && retryer.IsRetryable(err) {
 			failedAttempts++
 			d.Logger.Info("retrying", lager.Data{
 				"failed-attempts": failedAttempts,

--- a/retry_hijackable_client_test.go
+++ b/retry_hijackable_client_test.go
@@ -133,4 +133,24 @@ var _ = Describe("RetryHijackableClient", func() {
 			Expect(clientError).NotTo(HaveOccurred())
 		})
 	})
+
+	Context("when a retryer is not provided", func() {
+		BeforeEach(func() {
+			retryHijackableClient.Retryer = nil
+			fakeHijackableClient.DoReturns(nil, nil, syscall.ECONNRESET)
+			backOffAttempts := 0
+			fakeBackOff.NextBackOffStub = func() time.Duration {
+				backOffAttempts++
+				if backOffAttempts >= 2 {
+					return backoff.Stop
+				}
+				return 0 * time.Second
+			}
+		})
+
+		It("uses the default retryer", func() {
+			Expect(fakeHijackableClient.DoCallCount()).To(Equal(2))
+			Expect(clientError).To(Equal(syscall.ECONNRESET))
+		})
+	})
 })

--- a/retry_round_tripper.go
+++ b/retry_round_tripper.go
@@ -54,7 +54,11 @@ func (d *RetryRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 
 	backoff.Retry(func() error {
 		response, err = d.RoundTripper.RoundTrip(request)
-		if err != nil && !retryReadCloser.IsRead && d.Retryer.IsRetryable(err) {
+		retryer := d.Retryer
+		if retryer == nil {
+			retryer = &DefaultRetryer{}
+		}
+		if err != nil && !retryReadCloser.IsRead && retryer.IsRetryable(err) {
 			if request.Context().Err() != nil {
 				return backoff.Permanent(err)
 			}

--- a/retry_round_tripper_test.go
+++ b/retry_round_tripper_test.go
@@ -176,4 +176,24 @@ var _ = Describe("RetryRoundTripper", func() {
 			Expect(roundTripErr).To(Equal(innerErr))
 		})
 	})
+
+	Context("when a retryer is not provided", func() {
+		BeforeEach(func() {
+			retryRoundTripper.Retryer = nil
+			fakeRoundTripper.RoundTripReturns(nil, syscall.ECONNRESET)
+			backOffAttempts := 0
+			fakeBackOff.NextBackOffStub = func() time.Duration {
+				backOffAttempts++
+				if backOffAttempts >= 2 {
+					return backoff.Stop
+				}
+				return 0 * time.Second
+			}
+		})
+
+		It("uses the default retryer", func() {
+			Expect(fakeRoundTripper.RoundTripCallCount()).To(Equal(2))
+			Expect(roundTripErr).To(Equal(syscall.ECONNRESET))
+		})
+	})
 })


### PR DESCRIPTION
When a `Retryer` is not defined on `RetryRoundTripper` or `RetryHijackableClient`, a panic occurs because of a nil pointer dereference. This change fixes the panic by using a `DefaultRetryer` when no `Retryer` is provided.

The reason for doing this is that I saw a panic in docker-image resource in Concourse CI

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7f1153]

goroutine 1 [running]:
github.com/concourse/retryhttp.(*RetryRoundTripper).RoundTrip.func1()
        github.com/concourse/retryhttp@v1.2.4/retry_round_tripper.go:57 +0xf3
```
